### PR TITLE
Improved proxyRoute to support ssl and route patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,18 @@ drydock.proxyRoute({
 
 If your mock server is running on `localhost` port `1337`, opening `http://localhost:1337/google` in your browser will result in the HTML from `www.google.com`.
 
+forwardTo can alternatively take a function to dynamically determine the url.
+
+For example:
+
+```javascript
+drydock.proxyRoute({
+     method: "GET",
+     path: "/images/{path*}",
+     forwardTo: (request) => `https:/localhost:8080/images/${request.params.path}`
+});
+```
+
 
 #### State
 

--- a/src/node/routes/instance.js
+++ b/src/node/routes/instance.js
@@ -128,8 +128,14 @@ function defineProxyRoutes (drydock) {
           href
         } } = req;
 
+        delete headers.host;
+        let url = proxyRoute.forwardTo;
+        if (_.isFunction(proxyRoute.forwardTo)) {
+          url = proxyRoute.forwardTo(req);
+        }
+
         request({
-          url: proxyRoute.forwardTo,
+          url,
           method,
           headers,
           body: payload,

--- a/src/node/schemas.js
+++ b/src/node/schemas.js
@@ -42,7 +42,10 @@ export const staticRoute = Joi.object().keys({
 export const proxyRoute = Joi.object().keys({
   method: Joi.string().allow("*", "GET", "POST", "PUT", "DELETE", "PATCH").required(),
   path: Joi.string().required(),
-  forwardTo: Joi.string().required(),
+  forwardTo: Joi.alternatives().try(
+    Joi.string(),
+    Joi.func()
+  ).required()
 });
 
 export const delay = Joi.object().keys({


### PR DESCRIPTION
This fixes https://github.com/divmain/drydock/issues/11 and https://github.com/divmain/drydock/issues/12

It could still use some tests and documentation before merging, but I probably won't do this until we finish our prototype.  So I thought I would at least push the code and open a PR with the code if anyone wants or needs it.

I was on the fence if letting proxyRoute take a function was overkill but this is its current usage: 

```
 drydock.proxyRoute({
      method: "GET",
      path: "/something/{path*}",
      forwardTo: (request) => `https:/host/something/${request.params.path}` 
});
```
