### PR TITLE
Update to hapi 13.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint": "eslint src/",
     "start": "gulp",
     "test": "npm run lint && mocha --compilers js:babel-register",
-    "test:watch": "mocha --compilers js:babel-register --watch",
+    "test:watch": "mocha --compilers js:babel-register --watch"
   },
   "devDependencies": {
     "@divmain/eslint-config-defaults": "10.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "lint": "eslint src/",
     "start": "gulp",
     "test": "npm run lint && mocha --compilers js:babel-register",
-    "test:watch": "mocha --compilers js:babel-register --watch"
+    "test:watch": "mocha --compilers js:babel-register --watch",
+    "postinstall": "npm run build"
   },
   "devDependencies": {
     "@divmain/eslint-config-defaults": "10.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "start": "gulp",
     "test": "npm run lint && mocha --compilers js:babel-register",
     "test:watch": "mocha --compilers js:babel-register --watch",
-    "postinstall": "npm run build"
   },
   "devDependencies": {
     "@divmain/eslint-config-defaults": "10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "drydock",
   "main": "index.js",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "files": [
     "lib",
     "index.js",
@@ -16,7 +16,8 @@
     "copy": "cp src/ui/index.html lib/ui/index.html",
     "lint": "eslint src/",
     "start": "gulp",
-    "test": "npm run lint"
+    "test": "npm run lint && mocha --compilers js:babel-register",
+    "test:watch": "mocha --compilers js:babel-register --watch"
   },
   "devDependencies": {
     "@divmain/eslint-config-defaults": "10.0.0",
@@ -26,9 +27,11 @@
     "babel-plugin-transform-object-assign": "^6.3.13",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",
+    "chai": "^3.5.0",
     "css-loader": "^0.9.0",
     "eslint": "^2.2.0",
     "eslint-plugin-filenames": "^0.2.0",
+    "mocha": "^2.5.3",
     "raw-loader": "^0.5.1",
     "rimraf": "^2.4.4",
     "style-loader": "^0.8.2",
@@ -39,7 +42,8 @@
   "dependencies": {
     "bluebird": "^2.9.24",
     "core-js": "^2.0.2",
-    "hapi": "^6.8.1",
+    "hapi": "^13.4.1",
+    "inert": "^4.0.0",
     "joi": "^4.7.0",
     "lodash": "^2.4.1",
     "request": "^2.67.0",

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -1,5 +1,6 @@
 import { each, cloneDeep } from "lodash";
 import { Server } from "hapi";
+import Inert from 'inert';
 
 import { version } from "../../package.json";
 
@@ -87,12 +88,20 @@ export default class Drydock {
     if (this.verbose) {
       log(`starting drydock ${version} server on ${this.ip}:${this.port}...`);
     }
+    this.server = new Server();
 
-    this.server = new Server(this.ip, this.port, {
+    const options = {
+      host: this.ip,
+      port: this.port,
       router: { stripTrailingSlash: true },
-      cors: this.cors,
-      state: { cookies: { failAction: "ignore" } }
-    });
+      routes: {
+        cors: this.cors,
+        state: { failAction: "ignore" }
+      }
+    };
+    this.server.connection(options);
+    this.server.register(Inert, () => {});
+
 
     defineApiRoutes(this);
     defineInstanceRoutes(this);

--- a/test/drydock.spec.js
+++ b/test/drydock.spec.js
@@ -1,0 +1,46 @@
+import Drydock from '../src/node/index.js';
+
+var assert = require('chai').assert;
+var expect = require('chai').expect;
+
+describe('DryDock', () => {
+  let drydock;
+  let drydock2;
+  beforeEach(() => {
+    drydock = new Drydock({port: 9797});
+
+  });
+
+  afterEach(() => {
+    return Promise.all([
+      new Promise(resolve => drydock.stop(resolve)),
+      new Promise(resolve => {
+        if (!drydock2) {
+          resolve();
+          return;
+        }
+        drydock2.stop(resolve);
+      })]);
+  });
+
+  describe('starting instance', () => {
+    it('should invoke callback when started', (done) => {
+       drydock.start((error) => {
+         expect(error).to.be.undefined;
+         done();
+       });
+    });
+
+    it('should invoke callback with error if port is in use', (done) => {
+      drydock.start((error) => {
+        expect(error).to.be.undefined;
+
+        drydock2 = new Drydock({port: 9797});
+        drydock2.start((error) => {
+          expect(error).not.to.be.undefined;
+          done()
+        });
+      });
+    });
+  });
+});

--- a/test/drydock.spec.js
+++ b/test/drydock.spec.js
@@ -38,7 +38,7 @@ describe('DryDock', () => {
         drydock2 = new Drydock({port: 9797});
         drydock2.start((error) => {
           expect(error).not.to.be.undefined;
-          done()
+          done();
         });
       });
     });


### PR DESCRIPTION
This fixes issue where errors during startup (such as port in use) are not passed to start callback as noted in https://github.com/divmain/drydock/issues/10

We didn't have too much difficulty updating, but our test coverage is not very comprehensive.  HAPI is several versions ahead and I'm not entirely certain there may not be additional breaking changes in custom handler implementations and such.  I expect no one is doing anything fancy here and we didn't experience any breaking changes in our test suite.  

Closes #10.
