### PR TITLE
Allow case insensitive routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ lib
 
 # added by GitSavvy
 /npm-debug.log
+.npmrc

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ drydock.jsonRoute({
 
 Each handler function takes a request object.  This object will have the following properties:
 
+- `headers` - the headers of the HTTP request.
 - `payload` - the body of the HTTP request.
 - `params` - the parameters in the requested URL (see below).
 - `query` - the dictionary object equivalent of the query string.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ca-drydock",
   "main": "index.js",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "files": [
     "lib",
     "index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ca-drydock",
   "main": "index.js",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "files": [
     "lib",
     "index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "drydock",
+  "name": "ca-drydock",
   "main": "index.js",
   "version": "0.7.0",
   "files": [
@@ -18,10 +18,9 @@
     "start": "gulp",
     "test": "npm run lint && mocha --compilers js:babel-register",
     "test:watch": "mocha --compilers js:babel-register --watch",
-    "postinstall": "npm run build"
+    "prepublish": "npm run build"
   },
   "devDependencies": {
-    "@divmain/eslint-config-defaults": "10.0.0",
     "autoprefixer-loader": "^1.0.0",
     "babel-cli": "^6.3.15",
     "babel-eslint": "^6.0.0",
@@ -49,5 +48,8 @@
     "lodash": "^2.4.1",
     "request": "^2.67.0",
     "uuid": "^1.4.1"
+  },
+  "publishConfig": {
+    "registry": "http://npm-publish.f4tech.com"
   }
 }

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -88,7 +88,7 @@ export default class Drydock {
     if (this.verbose) {
       log(`starting drydock ${version} server on ${this.ip}:${this.port}...`);
     }
-    this.server = new Server();
+    this.server = new Server({ connections: { router: { isCaseSensitive: false } } });
 
     const options = {
       host: this.ip,

--- a/src/node/routes/instance.js
+++ b/src/node/routes/instance.js
@@ -48,6 +48,12 @@ function getHandlerArgs (req, handler) {
   return handlerArgs;
 }
 
+function getStatusCode(defaultCode, handlerCxt, handlerArgs) {
+  return (typeof defaultCode === 'function') ?
+            defaultCode.apply(handlerCxt, handlerArgs) :
+            defaultCode;
+}
+
 function defineDynamicRoutes (drydock) {
   drydock._initial.routes.forEach(routeCfg => {
     drydock.server.route({
@@ -61,11 +67,11 @@ function defineDynamicRoutes (drydock) {
 
         Promise.resolve()
           .then(() => drydockHandler.handler.apply(handlerCxt, handlerArgs))
-          .then(response => ({
+          .then(response => {
             payload: response,
             type: routeCfg.type,
-            code: routeCfg.defaultCode || 200
-          }))
+            code: getStatusCode(routeCfg.defaultCode, handlerCxt, handlerArgs) || 200
+          })
           .catch(Errors.HttpError, err => ({
             payload: err.payload,
             type: err.type,

--- a/src/node/routes/instance.js
+++ b/src/node/routes/instance.js
@@ -15,7 +15,7 @@ function getSelectedHandler (drydock, routeName) {
 
 function filterRequest (req) {
   return _.chain(req)
-    .pick("payload", "params", "query")
+    .pick("headers", "payload", "params", "query")
     .cloneDeep()
     .value();
 }

--- a/src/node/routes/instance.js
+++ b/src/node/routes/instance.js
@@ -68,9 +68,11 @@ function defineDynamicRoutes (drydock) {
         Promise.resolve()
           .then(() => drydockHandler.handler.apply(handlerCxt, handlerArgs))
           .then(response => {
-            payload: response,
-            type: routeCfg.type,
-            code: getStatusCode(routeCfg.defaultCode, handlerCxt, handlerArgs) || 200
+            return {
+              payload: response,
+              type: routeCfg.type,
+              code: getStatusCode(routeCfg.defaultCode, handlerCxt, handlerArgs) || 200
+            };
           })
           .catch(Errors.HttpError, err => ({
             payload: err.payload,

--- a/src/node/schemas.js
+++ b/src/node/schemas.js
@@ -22,7 +22,11 @@ export const route = Joi.object().keys({
   method: Joi.string().allow("*", "GET", "POST", "PUT", "DELETE", "PATCH").required(),
   path: Joi.string().required(),
   handlers: Joi.object().required(),
-  hostname: Joi.string().optional()
+  hostname: Joi.string().optional(),
+  defaultCode: Joi.alternatives().try(
+    Joi.number(),
+    Joi.func()
+  ).optional()
 });
 
 export const handler = Joi.object().keys({
@@ -36,7 +40,11 @@ export const handler = Joi.object().keys({
 
 export const staticRoute = Joi.object().keys({
   filePath: Joi.string().required(),
-  urlPath: Joi.string().required()
+  urlPath: Joi.string().required(),
+  defaultCode: Joi.alternatives().try(
+    Joi.number(),
+    Joi.func()
+  ).optional()
 });
 
 export const proxyRoute = Joi.object().keys({


### PR DESCRIPTION
This PR allows for case insensitive route registration and lookup. 

This story accompanies [S124040](https://rally1.rallydev.com/#/33116095857d/detail/userstory/67453001612?fdp=true). The same route can be called as `/defects` or `/Defects` which adds a lot of overhead and duplication to the test setups.
