### PR TITLE
Add support for specifying status codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Path values support parameters.  In our example above, if the user whose name wa
 }
 ```
 
+Drydock routes return status code 200 by default, but it does support specifying what status code the response should have. See an example in the HTML route below. Currently, the `headers` option only support status codes.  
 
 #### HTML routes
 
@@ -220,6 +221,7 @@ drydock.htmlRoute({
   name: "get-name",
   method: "GET",
   path: "/api/name",
+  headers: { code: 201 }
   handlers: {
     "get-name-success": {
       description: "Return the name that was previously set.",

--- a/src/node/routes/instance.js
+++ b/src/node/routes/instance.js
@@ -58,13 +58,12 @@ function defineDynamicRoutes (drydock) {
         const drydockHandler = getSelectedHandler(drydock, routeCfg.name);
         const handlerCxt = getHandlerContext(drydock, req);
         const handlerArgs = getHandlerArgs(req, drydockHandler);
-
         Promise.resolve()
           .then(() => drydockHandler.handler.apply(handlerCxt, handlerArgs))
           .then(response => ({
             payload: response,
             type: routeCfg.type,
-            code: routeCfg.defaultCode || 200
+            code: routeCfg.headers && routeCfg.headers.code ? routeCfg.headers.code : 200
           }))
           .catch(Errors.HttpError, err => ({
             payload: err.payload,

--- a/src/node/schemas.js
+++ b/src/node/schemas.js
@@ -22,7 +22,8 @@ export const route = Joi.object().keys({
   method: Joi.string().allow("*", "GET", "POST", "PUT", "DELETE", "PATCH").required(),
   path: Joi.string().required(),
   handlers: Joi.object().required(),
-  hostname: Joi.string().optional()
+  hostname: Joi.string().optional(),
+  headers: Joi.object().optional()
 });
 
 export const handler = Joi.object().keys({

--- a/test/drydock.spec.js
+++ b/test/drydock.spec.js
@@ -105,4 +105,65 @@ describe('DryDock', () => {
       });
     });
   });
+
+  describe('Specifying Status Codes', () => {
+    let drydock;
+
+    beforeEach(() => {
+      drydock = new Drydock({ port: 9797 });
+
+      drydock.htmlRoute({
+        name: 'default',
+        method: 'GET',
+        path: '/200',
+        handlers: {
+          success: {
+            description: 'default',
+            handler: () => {}
+          }
+        }
+      });
+    });
+
+    afterEach((done) => {
+      new Promise(resolve => drydock.stop(resolve));
+      done();
+    });
+
+    it('returns status code 200 by default', (done) => {
+      drydock.start(() => {});
+      request(`http://127.0.0.1:9797/200`, function (error, response, body) {
+        expect(response.statusCode).to.eql(200);
+        done();
+      });
+    });
+
+    describe('when a status code is specified', () => {
+      const CODE = 201;
+      beforeEach(() => {
+        drydock = new Drydock({ port: 9797 });
+
+        drydock.htmlRoute({
+          name: `${CODE}`,
+          method: 'GET',
+          path: `/${CODE}`,
+          headers: { code: CODE },
+          handlers: {
+            success: {
+              description: `${CODE}`,
+              handler: () => {}
+            }
+          }
+        });
+      });
+
+      it('returns specified status code', (done) => {
+        drydock.start(() => {});
+        request(`http://127.0.0.1:9797/${CODE}`, function (error, response, body) {
+          expect(response.statusCode).to.eql(CODE);
+          done();
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
This PR adds support for specifying which status code a registered route should respond with. 

